### PR TITLE
Add email notification for OSP orders

### DIFF
--- a/.github/workflows/osp_extraction.yml
+++ b/.github/workflows/osp_extraction.yml
@@ -16,6 +16,11 @@ jobs:
       OSP_USERNAME:  ${{ secrets.OSP_USERNAME }}
       OSP_PASSWORD:  ${{ secrets.OSP_PASSWORD }}
       GCHAT_WEBHOOK: ${{ secrets.GCHAT_WEBHOOK }}
+      SMTP_SERVER:   ${{ secrets.SMTP_SERVER }}
+      SMTP_PORT:     ${{ secrets.SMTP_PORT }}
+      SMTP_USER:     ${{ secrets.SMTP_USER }}
+      SMTP_PASS:     ${{ secrets.SMTP_PASS }}
+      EMAIL_TO:      ${{ secrets.EMAIL_TO }}
 
     steps:
       - name: 📥 Check out code


### PR DESCRIPTION
## Summary
- add SMTP settings and helper to email extracted orders
- call `send_orders_email` in the extraction workflow
- propagate SMTP secrets into GitHub Actions workflow

## Testing
- `python -m py_compile extractor.py`


------
https://chatgpt.com/codex/tasks/task_e_687e8664a2fc8321bf0bcbd92403c19a