### PR TITLE
Fix item summary lookup for MIN-indexed product data

### DIFF
--- a/extractor.py
+++ b/extractor.py
@@ -181,7 +181,13 @@ def create_item_summary_card(
 
     by_dept = summary_data.get("by_dept") if isinstance(summary_data, dict) else None
     if by_dept and prod_df is not None:
-        lookup = prod_df.set_index("MIN")["Item Name"]
+        # ``prod_df`` may already be indexed by MIN. If so, ``MIN`` will not
+        # appear as a column. Fall back to using the existing index in that case
+        # so lookups by MIN still succeed.
+        if "MIN" in prod_df.columns:
+            lookup = prod_df.set_index("MIN")["Item Name"]
+        else:
+            lookup = prod_df["Item Name"]
         for dept, mins in by_dept.items():
             items: List[Dict[str, Any]] = [
                 {"title": "MIN"},


### PR DESCRIPTION
## Summary
- make item summary card robust when product data already indexed by MIN

## Testing
- `python extractor.py` *(fails: BrowserType.launch: Executable doesn't exist)*
- `playwright install chromium` *(fails: Download failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_6898eb36e0f48321bdf24db42176a23d