### PR TITLE
Improve Google Chat card table readability

### DIFF
--- a/extractor.py
+++ b/extractor.py
@@ -191,7 +191,7 @@ def create_item_summary_card(
         for dept, mins in by_dept.items():
             items: List[Dict[str, Any]] = [
                 {"title": "MIN"},
-                {"title": "Item"},
+                {"title": "Item", "wrapText": True},
                 {"title": "Count"},
             ]
             for m, cnt in mins.items():
@@ -202,7 +202,7 @@ def create_item_summary_card(
                     name = "Unknown"
                 items.extend([
                     {"title": m},
-                    {"title": name},
+                    {"title": name, "wrapText": True},
                     {"title": str(cnt)},
                 ])
             sections.append(
@@ -212,6 +212,7 @@ def create_item_summary_card(
                         {
                             "grid": {
                                 "columnCount": 3,
+                                "columnStretch": [1, 4, 1],
                                 "borderStyle": {"type": "STROKE"},
                                 "items": items,
                             }


### PR DESCRIPTION
## Summary
- widen product table column and enable wrapping in Google Chat cards

## Testing
- `python -m py_compile extractor.py`


------
https://chatgpt.com/codex/tasks/task_e_6898eef6e23083218a3f7999df120c48