### PR TITLE
Fix invalid Google Chat card fields causing 400 errors

### DIFF
--- a/extractor.py
+++ b/extractor.py
@@ -191,7 +191,7 @@ def create_item_summary_card(
         for dept, mins in by_dept.items():
             items: List[Dict[str, Any]] = [
                 {"title": "MIN"},
-                {"title": "Item", "wrapText": True},
+                {"title": "Item", "columnSpan": 2},
                 {"title": "Count"},
             ]
             for m, cnt in mins.items():
@@ -202,7 +202,7 @@ def create_item_summary_card(
                     name = "Unknown"
                 items.extend([
                     {"title": m},
-                    {"title": name, "wrapText": True},
+                    {"title": name, "columnSpan": 2},
                     {"title": str(cnt)},
                 ])
             sections.append(
@@ -211,8 +211,7 @@ def create_item_summary_card(
                     "widgets": [
                         {
                             "grid": {
-                                "columnCount": 3,
-                                "columnStretch": [1, 4, 1],
+                                "columnCount": 4,
                                 "borderStyle": {"type": "STROKE"},
                                 "items": items,
                             }


### PR DESCRIPTION
## Summary
- remove unsupported `wrapText` and `columnStretch` fields from item summary card grids
- span the item name across two columns to keep the middle column wide enough

## Testing
- `python -m py_compile extractor.py`


------
https://chatgpt.com/codex/tasks/task_e_6898f6f5689083218042678cc59a945f